### PR TITLE
Bug fixes, input validation

### DIFF
--- a/DungeonManager/Character.cs
+++ b/DungeonManager/Character.cs
@@ -64,6 +64,7 @@ namespace DungeonManager
             _guid = Guid.NewGuid().ToString();
         }
 
+        [System.Xml.Serialization.XmlIgnore]
         public int ProficiencyBonus
         {
             get 
@@ -71,10 +72,6 @@ namespace DungeonManager
                 int totalLevel = Levels.Sum(item => item._level);
                 return 2 + (totalLevel - 1) / 4;
             }
-            set { }
-            // Proficiency value is calculated and set by external calling code, this is not a clean design
-            // in order to not break the program, this empty setter has been provided.
-            // It should be safe to remove the offending external code along with this setter.
         }
 
         public static int GetModifier(int AbilityScore)

--- a/DungeonManager/CreateCharacterForm.cs
+++ b/DungeonManager/CreateCharacterForm.cs
@@ -65,15 +65,7 @@ namespace DungeonManager
                 ClassListBox.Items.Add(l._class + ":" + l._level);
                 totalLevels += l._level;
             }
-            if (totalLevels < 5)
-                c.ProficiencyBonus = 2;
-            else if (totalLevels < 9)
-                c.ProficiencyBonus = 3;
-            else if (totalLevels < 13)
-                c.ProficiencyBonus = 4;
-            else if (totalLevels < 17)
-                c.ProficiencyBonus = 5;
-            else c.ProficiencyBonus = 6;
+
 
             ProficiencyBonuxTextBox.Text = c.ProficiencyBonus.ToString();
 

--- a/DungeonManager/CreateCharacterForm.cs
+++ b/DungeonManager/CreateCharacterForm.cs
@@ -440,8 +440,25 @@ namespace DungeonManager
 
         private void button1_Click(object sender, EventArgs e)
         {
-            ClassListBox.Items.Add(ClassComboBox.Text +":"+ LevelNumericUpDown.Value);
-            c.Levels.Add(new Level() { _class = (CharacterClass)ClassComboBox.SelectedItem, _level = (int)LevelNumericUpDown.Value });
+            // Validate user input
+            CharacterClass charClass;
+            int level = (int)LevelNumericUpDown.Value;
+            if (level < 1 || level > 20)
+            {
+                MessageBox.Show("Added class level must be between 1 and 20");
+                return;
+            }
+            try
+            {
+                charClass = Util.GetClassFromString(ClassComboBox.Text);
+            }
+            catch(ArgumentOutOfRangeException ex)
+            {
+                MessageBox.Show("The entered class name: \"" + ClassComboBox.Text + "\" is not valid");
+                return;
+            }
+            c.Levels.Add(new Level() { _class = charClass, _level = level });
+            ClassListBox.Items.Add(charClass.ToString() +":"+ level);   
             ShowCharacter();
         }
 

--- a/DungeonManager/Util.cs
+++ b/DungeonManager/Util.cs
@@ -10,36 +10,10 @@ namespace DungeonManager
     {
         public static int GetModifier(int AbilityScore)
         {
-            switch (AbilityScore)
-            {
-                case 1: return -5;
-                case 2: return -4;
-                case 3: return -4;
-                case 4: return -3;
-                case 5: return -3;
-                case 6: return -2;
-                case 7: return -2;
-                case 8: return -1;
-                case 9: return -1;
-                case 10: return 0;
-                case 11: return 0;
-                case 12: return 1;
-                case 13: return 1;
-                case 14: return 2;
-                case 15: return 2;
-                case 16: return 3;
-                case 17: return 3;
-                case 18: return 4;
-                case 19: return 4;
-                case 20: return 5;
-                case 21: return 5;
-                case 22: return 6;
-                case 23: return 6;
-                case 24: return 7;
-                case 25: return 8;
-                default: throw new ArgumentOutOfRangeException("Must be 1 through 25");
-
-            }
+            // As per DMG, 30 is the largest ability score a creature can have.
+            if(AbilityScore < 1 || AbilityScore > 30)
+                throw new ArgumentOutOfRangeException("Must be 1 through 25");
+            return (int) Math.Floor(((double)(AbilityScore - 10)) / 2.0);
         }
 
         public static CharacterRace GetRaceFromString(string s)
@@ -61,69 +35,37 @@ namespace DungeonManager
 
         public static CharacterClass GetClassFromString(string s)
         {
+            // allow for more tolerance when checking class name
+            s = s.Trim().ToLowerInvariant();
             switch (s)
             {
-                case "Barbarian": return CharacterClass.Barbarian;
-                case "Bard": return CharacterClass.Bard;
-                case "Cleric": return CharacterClass.Cleric;
-                case "Druid": return CharacterClass.Druid;
-                case "Fighter": return CharacterClass.Fighter;
-                case "Monk": return CharacterClass.Monk;
-                case "Paladin": return CharacterClass.Paladin;
-                case "Ranger": return CharacterClass.Ranger;
-                case "Rogue": return CharacterClass.Rogue;
-                case "Sorcerer": return CharacterClass.Sorcerer;
-                case "Warlock": return CharacterClass.Warlock;
-                case "Wizard": return CharacterClass.Wizard;
+                case "barbarian": return CharacterClass.Barbarian;
+                case "bard": return CharacterClass.Bard;
+                case "cleric": return CharacterClass.Cleric;
+                case "druid": return CharacterClass.Druid;
+                case "fighter": return CharacterClass.Fighter;
+                case "monk": return CharacterClass.Monk;
+                case "paladin": return CharacterClass.Paladin;
+                case "ranger": return CharacterClass.Ranger;
+                case "rogue": return CharacterClass.Rogue;
+                case "sorcerer": return CharacterClass.Sorcerer;
+                case "warlock": return CharacterClass.Warlock;
+                case "wizard": return CharacterClass.Wizard;
                 default: throw new ArgumentOutOfRangeException("Unrecognized Class string");
             }
         }
 
+        // Logically this function belongs to the character class, but has not been removed for compatibility reason
+        // calls to this method should be removed and replaced with the version found in Character
         public static int GetSpellDC(Character c)
         {
-            int retVal = 0;
-            foreach (Level l in c.Levels)
-            {
-                int t = 0;
-                switch (l._class)
-                {
-                    //charisma
-                    case CharacterClass.Bard:
-                    case CharacterClass.Sorcerer:
-                    case CharacterClass.Paladin:
-                    case CharacterClass.Warlock:
-                        {
-                            t = 8 + c.ProficiencyBonus + GetModifier(c.Charisma);
-                            break;
-                        }
-                    //int
-                    case CharacterClass.Fighter:
-                    case CharacterClass.Rogue:
-                    case CharacterClass.Wizard:
-                        {
-                            retVal = 8 + c.ProficiencyBonus + GetModifier(c.Intelligence);
-                            break;
-                        }
-                    //wis
-                    case CharacterClass.Druid:
-                    case CharacterClass.Ranger:
-                    case CharacterClass.Cleric:
-                        {
-                            retVal = 8 + c.ProficiencyBonus + GetModifier(c.Wisdom);
-                            break;
-                        }
-                    default: break;
-                }
-                if (t > retVal)
-                    retVal = t;
-
-            }
-            return retVal;
+            return c.SpellDC;
         }
 
+        // See comment for GetSpellDC
         public static int GetSpellAttackModifier(Character c)
         {
-            return GetSpellDC(c) - 8;
+            return c.SpellAttackModifier;
         }
     }
 }


### PR DESCRIPTION
This pull request includes several changes: It fixes the exception caused by trying to enter an invalid class name (or typing a valid class name without selecting it from the list) and disallows adding classes with zero levels. fixes #1 
The maximum ability score was raised to 30 in accordance with the game rules, consider uncapping it completely. 
Your algorithm for determining the spell casting attribute always chose the first one it encountered rather than the highest one as you probably intended so I reworked that to always take the highest stat. I also reworked the proficiency and ability modifier algorithms to use formulas instead of lookups.

The class-name parser has been made a little more robust and should accept all cApiTalizatiOn variants now.

SpellAttackModifier and SpellDC are definately properties of a character, and - if following OO-design principles - should be inside that class.
